### PR TITLE
Link xxhash statically with subproject fallback

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -90,7 +90,7 @@ eigen = dependency('eigen3').as_system()
 
 fmt = dependency('fmt', static: true).as_system()
 
-libxxhash = dependency('libxxhash').as_system()
+libxxhash = dependency('libxxhash', static: true, fallback: ['xxhash', 'xxhash_dep']).as_system()
 
 if host_machine.system() == 'windows'
   # We should have a system of 'cygwin' for cygwin.


### PR DESCRIPTION
## Summary
- Add `static: true` to xxhash dependency to link statically
- Add `fallback: ['xxhash', 'xxhash_dep']` to use subproject when system library unavailable

## Problem
On macOS ARM, when the system xxhash library changes or has rpath issues, bali-phy fails at runtime with:
```
dyld: Library not loaded: @rpath/libxxhash.0.dylib
  Reason: no LC_RPATH's found
```

This was required for successful building on macOS ARM.

## Solution
Link xxhash statically (like fmt already does) and add fallback to the bundled subproject. This ensures the library is always available at runtime.

## Test plan
- [x] `ninja -C build test` passes all 222 tests locally on macOS ARM

🤖 Generated with [Claude Code](https://claude.com/claude-code)