### PR TITLE
Fix inverted I/D labels in joint-indels --details output

### DIFF
--- a/src/tools/joint-indels.cc
+++ b/src/tools/joint-indels.cc
@@ -299,7 +299,7 @@ void run_analysis(const variables_map& args, const joint_A_T& J) {
                     std::cout << sample_num << "\t"
                               << indel.start1 << "\t" << indel.start2 << "\t"
                               << indel.end1 << "\t" << indel.end2 << "\t"
-                              << (indel.type == states::G1 ? "I" : "D") << "\t"
+                              << (indel.type == states::G1 ? "D" : "I") << "\t"
                               << indel.length << "\t"
                               << len1 << "\t" << len2 << "\t"
                               << indel.sequence << endl;


### PR DESCRIPTION
🤖

## Summary

The `joint-indels --details` output had inverted labels for insertions and deletions.

From the parent→child evolutionary perspective along a branch:
- **G1** (gap in child sequence, characters in parent): The parent has characters that the child lacks, meaning the child *lost* characters → this is a **Deletion**
- **G2** (gap in parent sequence, characters in child): The child has characters that the parent lacks, meaning the child *gained* characters → this is an **Insertion**

The code was labeling these backwards:
```cpp
// Before (wrong):
(indel.type == states::G1 ? "I" : "D")

// After (correct):
(indel.type == states::G1 ? "D" : "I")
```

This bug caused net indel calculations to have the wrong sign, making it impossible to reconstruct sequence lengths from the indel history. For example, if a branch had 3 insertions and 1 deletion, the output would incorrectly report 3 deletions and 1 insertion.

## Test plan
- [ ] Verify with sample data that net indel calculations now have correct sign
- [ ] Confirm sequence lengths can be reconstructed from indel history

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>